### PR TITLE
Add French count locale

### DIFF
--- a/ovos_skill_count/locale/fr-fr/cardinal.voc
+++ b/ovos_skill_count/locale/fr-fr/cardinal.voc
@@ -1,0 +1,2 @@
+nombre cardinal
+nombres cardinaux

--- a/ovos_skill_count/locale/fr-fr/count_to_N.error.dialog
+++ b/ovos_skill_count/locale/fr-fr/count_to_N.error.dialog
@@ -1,0 +1,1 @@
+Je n'ai pas compris jusqu'à quel nombre vous voulez que je compte.

--- a/ovos_skill_count/locale/fr-fr/count_to_N.intent
+++ b/ovos_skill_count/locale/fr-fr/count_to_N.intent
@@ -1,0 +1,16 @@
+compte jusqu'à #
+compte jusqu'à ##
+compte jusqu'à ###
+compte jusqu'à ####
+compte jusqu'à #####
+compte jusqu'à ######
+compte à l'infini
+compte indéfiniment
+compte jusqu'à # en échelle longue
+compte jusqu'à # en échelle courte
+compte jusqu'à ## en échelle longue
+compte jusqu'à ## en échelle courte
+compte jusqu'à # avec les nombres cardinaux
+compte jusqu'à # avec les nombres ordinaux
+compte à l'infini avec les nombres cardinaux
+compte à l'infini avec les nombres ordinaux

--- a/ovos_skill_count/locale/fr-fr/failed_extract_number.dialog
+++ b/ovos_skill_count/locale/fr-fr/failed_extract_number.dialog
@@ -1,0 +1,1 @@
+Je n'ai pas compris jusqu'à quel nombre vous voulez que je compte.

--- a/ovos_skill_count/locale/fr-fr/infinity.voc
+++ b/ovos_skill_count/locale/fr-fr/infinity.voc
@@ -1,0 +1,2 @@
+à l'infini
+indéfiniment

--- a/ovos_skill_count/locale/fr-fr/long_scale.voc
+++ b/ovos_skill_count/locale/fr-fr/long_scale.voc
@@ -1,0 +1,1 @@
+échelle longue

--- a/ovos_skill_count/locale/fr-fr/ordinal.voc
+++ b/ovos_skill_count/locale/fr-fr/ordinal.voc
@@ -1,0 +1,2 @@
+nombre ordinal
+nombres ordinaux

--- a/ovos_skill_count/locale/fr-fr/short_scale.voc
+++ b/ovos_skill_count/locale/fr-fr/short_scale.voc
@@ -1,0 +1,1 @@
+échelle courte

--- a/translations/fr-fr/dialogs.json
+++ b/translations/fr-fr/dialogs.json
@@ -1,0 +1,5 @@
+{
+  "failed_extract_number.dialog": [
+    "Je n'ai pas compris jusqu'à quel nombre vous voulez que je compte."
+  ]
+}

--- a/translations/fr-fr/intents.json
+++ b/translations/fr-fr/intents.json
@@ -1,0 +1,20 @@
+{
+  "count_to_N.intent": [
+    "compte jusqu'à #",
+    "compte jusqu'à ##",
+    "compte jusqu'à ###",
+    "compte jusqu'à ####",
+    "compte jusqu'à #####",
+    "compte jusqu'à ######",
+    "compte à l'infini",
+    "compte indéfiniment",
+    "compte jusqu'à # en échelle longue",
+    "compte jusqu'à # en échelle courte",
+    "compte jusqu'à ## en échelle longue",
+    "compte jusqu'à ## en échelle courte",
+    "compte jusqu'à # avec les nombres cardinaux",
+    "compte jusqu'à # avec les nombres ordinaux",
+    "compte à l'infini avec les nombres cardinaux",
+    "compte à l'infini avec les nombres ordinaux"
+  ]
+}

--- a/translations/fr-fr/vocabs.json
+++ b/translations/fr-fr/vocabs.json
@@ -1,0 +1,20 @@
+{
+  "infinity.voc": [
+    "à l'infini",
+    "indéfiniment"
+  ],
+  "cardinal.voc": [
+    "nombre cardinal",
+    "nombres cardinaux"
+  ],
+  "ordinal.voc": [
+    "nombre ordinal",
+    "nombres ordinaux"
+  ],
+  "long_scale.voc": [
+    "échelle longue"
+  ],
+  "short_scale.voc": [
+    "échelle courte"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a complete French locale tree for the count skill
- keep the French counting commands concise and natural for spoken use

## Validation
- verified fr-fr file coverage against ovos_skill_count/locale/en-us