### PR TITLE
feat: add da-DK and sv-SE translations

### DIFF
--- a/ovos_skill_count/locale/da-DK/cardinal.voc
+++ b/ovos_skill_count/locale/da-DK/cardinal.voc
@@ -1,0 +1,2 @@
+kardinaltal
+grundtal

--- a/ovos_skill_count/locale/da-DK/count_to_n.intent
+++ b/ovos_skill_count/locale/da-DK/count_to_n.intent
@@ -1,0 +1,16 @@
+tæl til #
+tæl til ##
+tæl til ###
+tæl til ####
+tæl til #####
+tæl til ######
+tæl for evigt
+tæl uendeligt
+tæl til # i lang skala
+tæl til # i kort skala
+tæl til ## i lang skala
+tæl til ## i kort skala
+tæl til # med kardinaltal
+tæl til # med ordenstal
+tæl for evigt med kardinaltal
+tæl for evigt med ordenstal

--- a/ovos_skill_count/locale/da-DK/failed_extract_number.dialog
+++ b/ovos_skill_count/locale/da-DK/failed_extract_number.dialog
@@ -1,0 +1,1 @@
+Jeg forstod ikke hvilket tal du ville have mig til at tælle til

--- a/ovos_skill_count/locale/da-DK/infinity.voc
+++ b/ovos_skill_count/locale/da-DK/infinity.voc
@@ -1,0 +1,2 @@
+for evigt
+uendeligt

--- a/ovos_skill_count/locale/da-DK/long_scale.voc
+++ b/ovos_skill_count/locale/da-DK/long_scale.voc
@@ -1,0 +1,1 @@
+lang skala

--- a/ovos_skill_count/locale/da-DK/ordinal.voc
+++ b/ovos_skill_count/locale/da-DK/ordinal.voc
@@ -1,0 +1,2 @@
+ordenstal
+ordinaltal

--- a/ovos_skill_count/locale/da-DK/short_scale.voc
+++ b/ovos_skill_count/locale/da-DK/short_scale.voc
@@ -1,0 +1,1 @@
+kort skala

--- a/ovos_skill_count/locale/sv-SE/cardinal.voc
+++ b/ovos_skill_count/locale/sv-SE/cardinal.voc
@@ -1,0 +1,2 @@
+kardinaltal
+grundtal

--- a/ovos_skill_count/locale/sv-SE/count_to_n.intent
+++ b/ovos_skill_count/locale/sv-SE/count_to_n.intent
@@ -1,0 +1,16 @@
+räkna till #
+räkna till ##
+räkna till ###
+räkna till ####
+räkna till #####
+räkna till ######
+räkna för evigt
+räkna oändligt
+räkna till # i lång skala
+räkna till # i kort skala
+räkna till ## i lång skala
+räkna till ## i kort skala
+räkna till # med kardinaltal
+räkna till # med ordningstal
+räkna för evigt med kardinaltal
+räkna för evigt med ordningstal

--- a/ovos_skill_count/locale/sv-SE/failed_extract_number.dialog
+++ b/ovos_skill_count/locale/sv-SE/failed_extract_number.dialog
@@ -1,0 +1,1 @@
+Jag förstod inte vilket tal du ville att jag skulle räkna till

--- a/ovos_skill_count/locale/sv-SE/infinity.voc
+++ b/ovos_skill_count/locale/sv-SE/infinity.voc
@@ -1,0 +1,2 @@
+för evigt
+oändligt

--- a/ovos_skill_count/locale/sv-SE/long_scale.voc
+++ b/ovos_skill_count/locale/sv-SE/long_scale.voc
@@ -1,0 +1,1 @@
+lång skala

--- a/ovos_skill_count/locale/sv-SE/ordinal.voc
+++ b/ovos_skill_count/locale/sv-SE/ordinal.voc
@@ -1,0 +1,2 @@
+ordningstal
+ordinaltal

--- a/ovos_skill_count/locale/sv-SE/short_scale.voc
+++ b/ovos_skill_count/locale/sv-SE/short_scale.voc
@@ -1,0 +1,1 @@
+kort skala


### PR DESCRIPTION
Neither Danish nor Swedish had any translation for this skill.

`count_to_n.intent` uses a compact wildcard-based template (16 lines: count to #/##/###/####/#####/######, forever, infinitely, with long/short scale and cardinal/ordinal variants) rather than the fully-expanded literal-number version seen in en-US (5499 lines) and pt-PT (5449 lines) - matching the pattern already used by fr-FR (16 lines), which relies on the `#` wildcard already matching arbitrary digit sequences rather than enumerating every number 0-99 with every modifier combination.

Also added the 5 small vocab/dialog files (cardinal.voc, ordinal.voc, short_scale.voc, long_scale.voc, infinity.voc, failed_extract_number.dialog) for both languages.

Verified with `ovos_localize.cli.validate` - clean, only the standard few_variants warning on the single-line dialog file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Danish and Swedish voice support for counting to specific numbers, counting indefinitely, and choosing cardinal or ordinal number formats.
  * Added localized terminology for cardinal numbers, ordinal numbers, long scale, short scale, and infinity.
  * Added localized responses when the requested counting number cannot be understood.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->