### PR TITLE
fix: accept canonical ovos.stop topic in stop tests

### DIFF
--- a/test/end2end/test_stop.py
+++ b/test/end2end/test_stop.py
@@ -28,7 +28,7 @@ SPOKE = {"speak", "ovos.utterance.speak"}
 # "nothing matched", either spelling (legacy / renamed)
 NO_MATCH = {"complete_intent_failure", "ovos.intent.unmatched"}
 # "a stop actually happened" — the broadcast every stoppable component obeys
-STOPPED = "mycroft.stop"
+STOPPED = {"mycroft.stop", "ovos.stop"}
 
 
 def _capture(minicroft, message, timeout=15):
@@ -53,8 +53,8 @@ class TestStopNoSkills(TestCase):
                                pipeline=["ovos-stop-pipeline-plugin-high"])
         message = make_utterance_message("stop", session=session)
         types = _capture(self.minicroft, message)
-        self.assertIn(STOPPED, types,
-                      f"exact 'stop' did not trigger a global stop ({types})")
+        self.assertTrue(STOPPED.intersection(types),
+                        f"exact 'stop' did not trigger a global stop ({types})")
 
     def test_fuzzy_stop_high_does_not_match(self):
         # at high confidence only an exact "stop" matches; a fuzzy phrase must
@@ -63,7 +63,7 @@ class TestStopNoSkills(TestCase):
                                pipeline=["ovos-stop-pipeline-plugin-high"])
         message = make_utterance_message("could you stop that", session=session)
         types = _capture(self.minicroft, message)
-        self.assertNotIn(STOPPED, types,
+        self.assertFalse(STOPPED.intersection(types),
                          f"fuzzy phrase should not stop at high confidence ({types})")
         self.assertTrue(NO_MATCH.intersection(types),
                         f"expected an unmatched signal ({types})")
@@ -74,8 +74,8 @@ class TestStopNoSkills(TestCase):
                                pipeline=["ovos-stop-pipeline-plugin-medium"])
         message = make_utterance_message("could you stop that", session=session)
         types = _capture(self.minicroft, message)
-        self.assertIn(STOPPED, types,
-                      f"fuzzy 'stop' did not match at medium confidence ({types})")
+        self.assertTrue(STOPPED.intersection(types),
+                        f"fuzzy 'stop' did not match at medium confidence ({types})")
 
 
 class TestCountSkills(TestCase):
@@ -145,7 +145,7 @@ class TestCountSkills(TestCase):
         stop = make_utterance_message("stop", session=session)
         types = _capture(self.minicroft, stop)
 
-        self.assertIn(STOPPED, types,
-                      f"global stop was not broadcast ({types})")
+        self.assertTrue(STOPPED.intersection(types),
+                        f"global stop was not broadcast ({types})")
         self.assertFalse(self.skill.active_sessions.get(session.session_id),
                          "counting kept running after global stop")


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

## Problem

Three stop-related tests were failing under ovos-core 3.x because they expected only the legacy `mycroft.stop` topic, but the current alpha emits the renamed canonical topic `ovos.stop`. The bug: the stop mechanism works correctly, but test assertions hardcoded a single string literal instead of accepting either spelling like the rest of this file does for bus message vocabulary drift.

## Solution

Made `STOPPED` a set containing both topic names (`{"mycroft.stop", "ovos.stop"}`), following the exact pattern already used by `SPOKE` and `NO_MATCH` constants in the same file. Updated all four assertions that check this constant to use set intersection instead of string membership, making the assertions drift-immune to bus message renames (as documented in the module docstring).

## Verification

All 6 tests in test_stop.py pass on three consecutive runs against ovos-core 3.0.4a1:

First run: `6 passed, 197 warnings in 65.79s`
Second run: `6 passed, 197 warnings in 70.05s`
Third run: `6 passed, 197 warnings in 70.18s`

The specifically-affected tests (test_exact_stop_triggers_global_stop, test_fuzzy_stop_medium_matches, test_global_stop_halts_counting) went from failing to passing.