### PR TITLE
fix: modernize stop-topic assertions and shut down skill-loading test instances

### DIFF
--- a/test/end2end/test_stop.py
+++ b/test/end2end/test_stop.py
@@ -28,7 +28,7 @@ SPOKE = {"speak", "ovos.utterance.speak"}
 # "nothing matched", either spelling (legacy / renamed)
 NO_MATCH = {"complete_intent_failure", "ovos.intent.unmatched"}
 # "a stop actually happened" — the broadcast every stoppable component obeys
-STOPPED = "mycroft.stop"
+STOPPED = {"mycroft.stop", "ovos.stop"}
 
 
 def _capture(minicroft, message, timeout=15):
@@ -53,8 +53,8 @@ class TestStopNoSkills(TestCase):
                                pipeline=["ovos-stop-pipeline-plugin-high"])
         message = make_utterance_message("stop", session=session)
         types = _capture(self.minicroft, message)
-        self.assertIn(STOPPED, types,
-                      f"exact 'stop' did not trigger a global stop ({types})")
+        self.assertTrue(STOPPED.intersection(types),
+                        f"exact 'stop' did not trigger a global stop ({types})")
 
     def test_fuzzy_stop_high_does_not_match(self):
         # at high confidence only an exact "stop" matches; a fuzzy phrase must
@@ -63,7 +63,7 @@ class TestStopNoSkills(TestCase):
                                pipeline=["ovos-stop-pipeline-plugin-high"])
         message = make_utterance_message("could you stop that", session=session)
         types = _capture(self.minicroft, message)
-        self.assertNotIn(STOPPED, types,
+        self.assertFalse(STOPPED.intersection(types),
                          f"fuzzy phrase should not stop at high confidence ({types})")
         self.assertTrue(NO_MATCH.intersection(types),
                         f"expected an unmatched signal ({types})")
@@ -74,8 +74,8 @@ class TestStopNoSkills(TestCase):
                                pipeline=["ovos-stop-pipeline-plugin-medium"])
         message = make_utterance_message("could you stop that", session=session)
         types = _capture(self.minicroft, message)
-        self.assertIn(STOPPED, types,
-                      f"fuzzy 'stop' did not match at medium confidence ({types})")
+        self.assertTrue(STOPPED.intersection(types),
+                        f"fuzzy 'stop' did not match at medium confidence ({types})")
 
 
 class TestCountSkills(TestCase):
@@ -145,7 +145,7 @@ class TestCountSkills(TestCase):
         stop = make_utterance_message("stop", session=session)
         types = _capture(self.minicroft, stop)
 
-        self.assertIn(STOPPED, types,
-                      f"global stop was not broadcast ({types})")
+        self.assertTrue(STOPPED.intersection(types),
+                        f"global stop was not broadcast ({types})")
         self.assertFalse(self.skill.active_sessions.get(session.session_id),
                          "counting kept running after global stop")

--- a/test/unittests/test_skill_loading.py
+++ b/test/unittests/test_skill_loading.py
@@ -18,9 +18,27 @@ class TestSkillLoading(unittest.TestCase):
         # SkillLoader must be pointed at the package dir.
         self.path = dirname(ovos_skill_count.__file__)
 
+    def setUp(self):
+        self.instances = []
+
+    def tearDown(self):
+        # each test may register bare skills and/or SkillLoader instances;
+        # shut them all down so their background threads (event scheduler,
+        # settings/file watchers) stop mutating shared bus/scheduler state
+        # before pytest tears down the next test's fixtures
+        for instance in self.instances:
+            try:
+                if isinstance(instance, SkillLoader):
+                    instance.deactivate()
+                else:
+                    instance.default_shutdown()
+            except Exception:
+                pass
+
     def test_from_class(self):
         bus = FakeBus()
         skill = CountSkill()
+        self.instances.append(skill)
         skill._startup(bus, self.skill_id)
         self.assertEqual(skill.bus, bus)
         self.assertEqual(skill.skill_id, self.skill_id)
@@ -30,6 +48,7 @@ class TestSkillLoading(unittest.TestCase):
         for skill_id, plug in find_skill_plugins().items():
             if skill_id == self.skill_id:
                 skill = plug()
+                self.instances.append(skill)
                 skill._startup(bus, self.skill_id)
                 self.assertEqual(skill.bus, bus)
                 self.assertEqual(skill.skill_id, self.skill_id)
@@ -40,6 +59,7 @@ class TestSkillLoading(unittest.TestCase):
     def test_from_loader(self):
         bus = FakeBus()
         loader = SkillLoader(bus, self.path)
+        self.instances.append(loader)
         loader.load()
         self.assertEqual(loader.instance.bus, bus)
         self.assertEqual(loader.instance.root_dir, self.path)
@@ -47,6 +67,7 @@ class TestSkillLoading(unittest.TestCase):
     def test_from_plugin_loader(self):
         bus = FakeBus()
         loader = PluginSkillLoader(bus, self.skill_id)
+        self.instances.append(loader)
         for skill_id, plug in find_skill_plugins().items():
             if skill_id == self.skill_id:
                 loader.load(plug)


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

This combines two test-suite repairs that turned out to depend on each other: neither could show green CI alone, together they do.

The stop tests hardcoded the legacy `mycroft.stop` topic. Current core emits the canonical `ovos.stop` instead, and the capture only ever sees one spelling, so three tests failed on current alphas. `STOPPED` is now a set accepting either spelling, the same pattern the file already uses for `NO_MATCH` and `SPOKE`. Verified red before and green after, three consecutive runs.

Separately, the skill-loading tests start skills and loaders but never shut them down. Workshop's background threads keep mutating shared state while pytest tears the fixtures down, which crashes CI's coverage job near-deterministically ("dictionary changed size during iteration") while never reproducing locally. A `tearDown` now stops every instance the tests create. The proof is CI-side: the coverage job failed twice in a row before this change and passes with it.
